### PR TITLE
Add updated clientside and serverside code to meet part 2 spec

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -15,46 +15,53 @@ errorHandler proc = do
         Nothing -> clog $ "Action successful."
         Just err -> clog $ "Received err: " ++ show err
 
-deliveryHandler :: Client (Either ClientError ClientDelivery) -> Client ()
-deliveryHandler proc = do
+deliveryHandler :: Bool -> Client (Either ClientError ClientDelivery) -> Client ()
+deliveryHandler isAck proc = do
     eitherDeliv <- proc
     case eitherDeliv of
         Left err -> clog $ "Get error: " ++ show err
         Right (ClientDelivery delivId body) -> do
             let message = unpackStrict8 body
             clog $ "Get successful: {Id: " ++ show delivId ++ ", Body: " ++ message ++ "}"
+            case isAck of
+                True -> do
+                    errorHandler $ ack delivId
+                False -> do
+                    errorHandler $ nack delivId
+
+consumeHandler :: ClientDelivery -> Client (Maybe String)
+consumeHandler (ClientDelivery delivId body) = do
+    let message = unpackStrict8 body
+    case (message == "stop") of
+        True -> do
             errorHandler $ ack delivId
+            return (Just "Received stop message")
+        False -> do
+            clog $ "Consumed message: {Id: " ++ show delivId ++ ", Body: " ++ message ++ "}"
+            errorHandler $ ack delivId
+            return Nothing
 
 main :: IO ()
 main = do
     let clientAddr = "127.0.0.1"
-        clientPort = "10502"
+        clientPort = "10503"
         serverAddr = "127.0.0.1:10501"
         serverName = "CHMQ-Server-0"
     eitherCNode <- newClientNode clientAddr clientPort
     case eitherCNode of
         Right cNode -> do
             runClient cNode serverAddr serverName $ do
-                errorHandler $ publish (pack "Hi there!")
-                maybeErr <- publish (pack "Hello world!")
-                case maybeErr of
-                    Just err -> do
-                        clog $ "Publish error."
-                    Nothing -> do
-                        clog $ "Publish successful."
-                eitherDeliv <- get
-                case eitherDeliv of
-                    Left err -> do
-                        clog $ "Get error: " ++ show err
-                    Right (ClientDelivery delivId body) -> do
-                        let message = unpackStrict8 body
-                        clog $ "Get successful: {Id: " ++ show delivId ++ ", Body: " ++ message ++ "}"
-                        maybeErr <- nack delivId
-                        case maybeErr of
-                            Just err -> do
-                                clog $ "Nack error: {Id: " ++ show delivId ++ "}"
-                            Nothing -> do
-                                clog $ "Nack successful: {Id: " ++ show delivId ++ "}"
-                        deliveryHandler $ get
+                errorHandler $ declareQueue "default"
+                -- eitherReturnData <- consume "default" False consumeHandler
+                -- case eitherReturnData of
+                --     Left err -> clog $ show err
+                --     Right returnData -> clog returnData
+                -- errorHandler $ declareQueue "test"
+                errorHandler $ publish "default" (pack "Hi there!")
+                errorHandler $ publish "default" (pack "stop")
+                -- errorHandler $ publish "default" (pack "Hi again!")
+                -- errorHandler $ publish "test" (pack "Test message")
+                -- deliveryHandler True $ get "default"
+                -- deliveryHandler False $ get "test"
                 liftIO $ threadDelay 9000000000
         Left error -> print error

--- a/devlog.md
+++ b/devlog.md
@@ -29,3 +29,6 @@
 12. Additionally, changed when the unackedItems list is not found for a connected client to close the connection
 13. Next step: add disconnect handler (similar to close connection behavior), begin work on client package
 14. Handle disconnections and write launchServer function to register server given a name
+
+
+When designing consumer behavior, initially assumed it would be okay to simply forward messages in publish but, if a client disconnects, that behavior must also happen when a unacked items are pushed back onto a the server queues

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -1,44 +1,40 @@
 module Main where
 
--- import Control.Distributed.Process
--- import Control.Distributed.Process.Node (initRemoteTable, runProcess, newLocalNode)
--- import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Control.Distributed.Process
+import Control.Distributed.Process.Node (initRemoteTable, runProcess, newLocalNode)
+import Network.Transport.TCP (createTransport, defaultTCPParameters)
 
--- import System.Environment (getArgs)
+import System.Environment (getArgs)
 
--- import ServerTypes
--- import Server
+import ServerTypes
+import Server
 
--- type Address = String
--- type Port = String
+type Address = String
+type Port = String
 
--- callLaunchServer :: Address -> Port -> ServerName -> IO ()
--- callLaunchServer address port name = do
---     -- Create a new tcp transport layer with the given args
---     eitherT <- createTransport address port defaultTCPParameters
---     case eitherT of
---         -- If creation is successful
---         Right t -> do
---             -- Create new local node on the transport layer
---             serverNode <- newLocalNode t initRemoteTable
---             -- Run that node as a CHMQ server
---             runProcess serverNode $ do
---                 launchServer name
---         -- If creation is unsuccessful, print the error
---         Left error -> print error
+callLaunchServer :: Address -> Port -> ServerName -> IO ()
+callLaunchServer address port name = do
+    -- Create a new tcp transport layer with the given args
+    eitherT <- createTransport address port defaultTCPParameters
+    case eitherT of
+        -- If creation is successful
+        Right t -> do
+            -- Create new local node on the transport layer
+            serverNode <- newLocalNode t initRemoteTable
+            -- Run that node as a CHMQ server
+            runProcess serverNode $ do
+                launchServer name
+        -- If creation is unsuccessful, print the error
+        Left error -> print error
 
-
--- main :: IO ()
--- main = do
---     -- Get server address, port, and name: default to localhost:10501 and CHMQ-Server-0
---     args <- getArgs
---     case args of
---         [] -> callLaunchServer "127.0.0.1" "10501" "CHMQ-Server-0"
---         [address] -> callLaunchServer address "10501" "CHMQ-Server-0"
---         [address,port] -> callLaunchServer address port "CHMQ-Server-0"
---         [address,port,name] -> callLaunchServer address port name
---         _ -> print "Too many arguments passed. Please give arguments in the form: address port name"
 
 main :: IO ()
 main = do
-    putStrLn "chmq-server-exe"
+    -- Get server address, port, and name: default to localhost:10501 and CHMQ-Server-0
+    args <- getArgs
+    case args of
+        [] -> callLaunchServer "127.0.0.1" "10501" "CHMQ-Server-0"
+        [address] -> callLaunchServer address "10501" "CHMQ-Server-0"
+        [address,port] -> callLaunchServer address port "CHMQ-Server-0"
+        [address,port,name] -> callLaunchServer address port name
+        _ -> print "Too many arguments passed. Please give arguments in the form: address port name"

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -1,40 +1,44 @@
 module Main where
 
-import Control.Distributed.Process
-import Control.Distributed.Process.Node (initRemoteTable, runProcess, newLocalNode)
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+-- import Control.Distributed.Process
+-- import Control.Distributed.Process.Node (initRemoteTable, runProcess, newLocalNode)
+-- import Network.Transport.TCP (createTransport, defaultTCPParameters)
 
-import System.Environment (getArgs)
+-- import System.Environment (getArgs)
 
-import ServerTypes
-import Server
+-- import ServerTypes
+-- import Server
 
-type Address = String
-type Port = String
+-- type Address = String
+-- type Port = String
 
-callLaunchServer :: Address -> Port -> ServerName -> IO ()
-callLaunchServer address port name = do
-    -- Create a new tcp transport layer with the given args
-    eitherT <- createTransport address port defaultTCPParameters
-    case eitherT of
-        -- If creation is successful
-        Right t -> do
-            -- Create new local node on the transport layer
-            serverNode <- newLocalNode t initRemoteTable
-            -- Run that node as a CHMQ server
-            runProcess serverNode $ do
-                launchServer name
-        -- If creation is unsuccessful, print the error
-        Left error -> print error
+-- callLaunchServer :: Address -> Port -> ServerName -> IO ()
+-- callLaunchServer address port name = do
+--     -- Create a new tcp transport layer with the given args
+--     eitherT <- createTransport address port defaultTCPParameters
+--     case eitherT of
+--         -- If creation is successful
+--         Right t -> do
+--             -- Create new local node on the transport layer
+--             serverNode <- newLocalNode t initRemoteTable
+--             -- Run that node as a CHMQ server
+--             runProcess serverNode $ do
+--                 launchServer name
+--         -- If creation is unsuccessful, print the error
+--         Left error -> print error
 
+
+-- main :: IO ()
+-- main = do
+--     -- Get server address, port, and name: default to localhost:10501 and CHMQ-Server-0
+--     args <- getArgs
+--     case args of
+--         [] -> callLaunchServer "127.0.0.1" "10501" "CHMQ-Server-0"
+--         [address] -> callLaunchServer address "10501" "CHMQ-Server-0"
+--         [address,port] -> callLaunchServer address port "CHMQ-Server-0"
+--         [address,port,name] -> callLaunchServer address port name
+--         _ -> print "Too many arguments passed. Please give arguments in the form: address port name"
 
 main :: IO ()
 main = do
-    -- Get server address, port, and name: default to localhost:10501 and CHMQ-Server-0
-    args <- getArgs
-    case args of
-        [] -> callLaunchServer "127.0.0.1" "10501" "CHMQ-Server-0"
-        [address] -> callLaunchServer address "10501" "CHMQ-Server-0"
-        [address,port] -> callLaunchServer address port "CHMQ-Server-0"
-        [address,port,name] -> callLaunchServer address port name
-        _ -> print "Too many arguments passed. Please give arguments in the form: address port name"
+    putStrLn "chmq-server-exe"

--- a/src/Messages.hs
+++ b/src/Messages.hs
@@ -11,6 +11,7 @@ import Data.ByteString (ByteString)
 
 type PublishId = Int
 type DeliveryId = Int
+type QueueName = String
 
 -- Connection message for when a client wants to connect to the server
 data ClientConnection = ClientConnection {
@@ -48,7 +49,8 @@ instance Binary ConnectionClosedNotification
 data Publish = Publish {
     publisherId :: ProcessId,
     publishId :: PublishId,
-    publishBody :: ByteString
+    publishBody :: ByteString,
+    publishName :: QueueName
 } deriving (Typeable, Generic, Show)
 
 instance Binary Publish
@@ -62,16 +64,22 @@ instance Binary Confirm
 
 -- Get message for when client wants one message from the queue
 data Get = Get {
-    getterId :: ProcessId
+    getterId :: ProcessId,
+    getName :: QueueName
 } deriving (Typeable, Generic, Show)
 
 instance Binary Get
 
--- Notification for when a client "gets" from an empty queue
-data EmptyQueueNotification = EmptyQueueNotification
+data GetErrorNotification = EmptyQueueNotification | ExclusiveConsumerNotification
     deriving (Typeable, Generic, Show)
 
-instance Binary EmptyQueueNotification
+instance Binary GetErrorNotification
+
+-- -- Notification for when a client "gets" from an empty queue
+-- data EmptyQueueNotification = EmptyQueueNotification
+--     deriving (Typeable, Generic, Show)
+
+-- instance Binary EmptyQueueNotification
 
 -- Delivery message for the server sending a item in the queue to a client
 data Delivery = Delivery {
@@ -96,3 +104,36 @@ data Nack = Nack {
 } deriving (Typeable, Generic, Show)
 
 instance Binary Nack
+
+-- QueueDeclare message for a declaring a new queue on the server
+data QueueDeclare = QueueDeclare {
+    declareId :: ProcessId,
+    declareName :: QueueName
+} deriving (Typeable, Generic, Show)
+
+instance Binary QueueDeclare
+
+-- Consume message for continuous consumption from a queue on the server
+data Consume = Consume {
+    consumeId :: ProcessId,
+    exclusive :: Bool
+} deriving (Typeable, Generic, Show)
+
+instance Binary Consume
+
+data ConsumeErrorNotification = 
+    -- RegisteredExclusiveConsumer reason is sent when there is a pre-existing
+    -- exclusive consumer for said queue
+      RegisteredExclusiveConsumer
+    -- RegisteredConsumersOnExclusive reason is sent when there are pre-existing
+    -- consumers for an exclusive consume call on said queue
+    | RegisteredConsumersOnExclusive
+    deriving (Typeable, Generic, Show)
+
+instance Binary ConsumeErrorNotification
+
+-- Message for publish/get/consume from non-existant queue
+data UnrecognizedQueueNameNotification = UnrecognizedQueueNameNotification
+    deriving (Typeable, Generic, Show)
+
+instance Binary UnrecognizedQueueNameNotification

--- a/src/Messages.hs
+++ b/src/Messages.hs
@@ -122,6 +122,13 @@ data Consume = Consume {
 
 instance Binary Consume
 
+data StopConsume = StopConsume {
+    stopConsumeId :: ProcessId,
+    stopConsumeName :: QueueName
+} deriving (Typeable, Generic, Show)
+
+instance Binary StopConsume
+
 data ConsumeErrorNotification = 
     -- RegisteredExclusiveConsumer reason is sent when there is a pre-existing
     -- exclusive consumer for said queue

--- a/src/Messages.hs
+++ b/src/Messages.hs
@@ -116,6 +116,7 @@ instance Binary QueueDeclare
 -- Consume message for continuous consumption from a queue on the server
 data Consume = Consume {
     consumeId :: ProcessId,
+    consumeName :: QueueName,
     exclusive :: Bool
 } deriving (Typeable, Generic, Show)
 

--- a/src/Queue.hs
+++ b/src/Queue.hs
@@ -20,3 +20,25 @@ pop queue =
             where
                 elem = Seq.index queue 0
                 queue' = Seq.drop 1 queue
+
+-- Pop an element from the left side of the queue with no regards to safety
+unsafePop :: Queue a -> (Queue a, a)
+unsafePop queue
+    | isEmpty queue = error "unsafePop call on empty queue"
+    | otherwise = 
+        (queue', elem)
+        where
+            elem = Seq.index queue 0
+            queue' = Seq.drop 1 queue
+
+isEmpty :: Queue a -> Bool
+isEmpty = Seq.null
+
+isElem :: (Eq a) => a -> Queue a -> Bool
+isElem = elem
+
+emptyQueue :: Queue a
+emptyQueue = Seq.empty
+
+removeQueueElem :: (Eq a) => a -> Queue a -> Queue a
+removeQueueElem elem queue = Seq.filter ((==) elem) queue

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -1,7 +1,6 @@
 module Server where
 
 import Control.Distributed.Process
-import qualified Data.Sequence as Seq
 import qualified Data.Map as Map
 
 import ServerTypes

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -18,6 +18,8 @@ runServer state = do
         , match $ ackHandler state
         , match $ nackHandler state
         , match $ disconnectHandler state
+        , match $ queueDeclareHandler state
+        , match $ consumeHandler state
         ]
     runServer state'
 
@@ -33,4 +35,4 @@ launchServer name = do
     -- register the server on a remotely accessible table
     registerRemoteAsync selfNodeId name selfProcId
     -- run the server
-    runServer $ ServerState name Map.empty Map.empty Seq.empty 0
+    runServer $ ServerState name Map.empty Map.empty Map.empty 0

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -19,6 +19,7 @@ runServer state = do
         , match $ disconnectHandler state
         , match $ queueDeclareHandler state
         , match $ consumeHandler state
+        , match $ stopConsumeHandler state
         ]
     runServer state'
 

--- a/src/ServerHandlers.hs
+++ b/src/ServerHandlers.hs
@@ -34,7 +34,58 @@ clientConnHandler
                 -- Return modified state
                 return $ ServerState name clients' clientItems' queues nextDelivId
 
--- publish still needs to forward message to next consumer if there is one
+-- unsafe on empty queue
+nextConsumer :: Queue ClientId -> (ClientId, Queue ClientId)
+nextConsumer queue
+    | isEmpty queue = error "nextConsumer call on empty queue"
+    | otherwise =
+        (consumer, queue'')
+        where
+            (queue', consumer) = unsafePop queue
+            queue'' = push consumer queue'
+
+-- pushes new item onto given server queue or forwards it to the next consumer 
+-- for that queue
+pushOrForward :: ServerState -> Item -> ServerQueue -> Process ServerState
+pushOrForward
+    (ServerState name clients clientItems queues nextDelivId)
+    (Item source body)
+    (ServerQueue queue exFlag consumers) = do
+        -- Check if there are registered consumers
+        case isEmpty consumers of
+            -- If there aren't any registered,
+            True -> do
+                -- Push the new item into the queue and update the ServerQueues map
+                let queue' = push (Item source body) queue
+                    queues' = Map.insert source (ServerQueue queue' exFlag consumers) queues
+                -- Return modified state
+                return $ ServerState name clients clientItems queues' nextDelivId
+            -- If there are some registered,
+            False -> do
+                -- Get the next consumer and update the ServerQueues map
+                let (consumer, consumers') = nextConsumer consumers
+                    queues' = Map.insert source (ServerQueue queue exFlag consumers') queues
+                    nextDelivId' = nextDelivId + 1
+                    item = Item source body
+                -- Get consumers unackedItems map
+                case Map.lookup consumer clientItems of
+                    -- If consumers map doesn't exist, create it and insert the item
+                    Nothing -> do
+                        let unackedItems' = Map.fromList [(nextDelivId, item)]
+                            clientItems' = Map.insert consumer unackedItems' clientItems
+                        -- Send item to consumer
+                        send consumer $ Delivery nextDelivId body
+                        -- Return modified state
+                        return $ ServerState name clients clientItems' queues' nextDelivId'
+                    -- If consumers map does exist, just insert the item
+                    Just unackedItems -> do
+                        let unackedItems' = Map.insert nextDelivId item unackedItems
+                            clientItems' = Map.insert consumer unackedItems' clientItems
+                        -- Send item to consumer
+                        send consumer $ Delivery nextDelivId body
+                        -- Return modified state
+                        return $ ServerState name clients clientItems' queues' nextDelivId'
+
 -- Handler function for when a client publishes an item to the queue
 publishHandler :: ServerState -> Publish -> Process ServerState
 publishHandler 
@@ -51,23 +102,25 @@ publishHandler
                 return $ ServerState name clients clientItems queues nextDelivId
             -- If message is received from connected client
             False -> do
+                say "Looking up server queue..."
                 -- Lookup server queue by name
                 case Map.lookup queueName queues of
                     -- If queue doesn't exist,
                     Nothing -> do
+                        say "Queue not found. Sending error back to client..."
                         -- Send an unrecognized queue name notification
                         send publisherId UnrecognizedQueueNameNotification
                         -- Return state
                         return $ ServerState name clients clientItems queues nextDelivId
                     -- If queue does exist,
-                    Just (ServerQueue queue exFlag consumers) -> do
-                        -- Push the new item into the queue and update the ServerQueues map
-                        let queue' = push (Item queueName itemBody) queue
-                            queues' = Map.insert queueName (ServerQueue queue' exFlag consumers) queues
+                    Just sQueue -> do
+                        say "Queue found. Push/forwarding message and confirming with client..."
+                        let state = ServerState name clients clientItems queues nextDelivId
+                            item = Item queueName itemBody
+                        state' <- pushOrForward state item sQueue
                         -- Confirm receipt to publisher
                         send publisherId $ Confirm itemId
-                        -- Return modified state
-                        return $ ServerState name clients clientItems queues' nextDelivId
+                        return state'
 
 -- Handler function for when a client requests an item from the queue
 getHandler :: ServerState -> Get -> Process ServerState
@@ -85,35 +138,42 @@ getHandler
                 return $ ServerState name clients clientItems queues nextDelivId
             -- If message is received from connected client
             False -> do
+                say "Looking up server queue..."
                 case Map.lookup queueName queues of
                     -- If queue doesn't exist,
                     Nothing -> do
+                        say "Queue not found. Responding with error..."
                         -- Send an unrecognized queue name notification
                         send getterId UnrecognizedQueueNameNotification
                         -- Return state
                         return $ ServerState name clients clientItems queues nextDelivId
                     -- If queue does exist,
                     Just (ServerQueue queue exFlag consumers) -> do
+                        say "Server found. Checking exclusivitiy..."
                         case exFlag of
                             -- If queue is being exclusively consumed,
                             True -> do
+                                say "Queue marked exclusive. Responding with error..."
                                 -- Send a get error notification
                                 send getterId ExclusiveConsumerNotification
                                 -- Return state
                                 return $ ServerState name clients clientItems queues nextDelivId
                             -- If queue is not being exclusively consumed,
                             False -> do
+                                say "Queue not exclusive. Attempting to pop item from queue..."
                                 -- Pop an item from the queue
                                 let (queue', maybeItem) = pop queue
                                 case maybeItem of
                                     -- If queue is empty,
                                     Nothing -> do
+                                        say "Queue empty. Responding with empty queue notification..."
                                         -- Send empty queue notif to client
                                         send getterId EmptyQueueNotification
                                         -- Return state
                                         return $ ServerState name clients clientItems queues nextDelivId
                                     -- If queue is not empty,
                                     Just (Item source body) -> do
+                                        say "Item popped. Sending delivery to client..."
                                         let nextDelivId' = nextDelivId + 1
                                             item = Item source body
                                         -- Get getter's unackedItems map
@@ -137,167 +197,286 @@ getHandler
                                                 -- Return modified state
                                                 return $ ServerState name clients clientItems' queues' nextDelivId'
 
--- pushUnacked :: UnackedItems -> Queue Item -> Queue Item
--- pushUnacked unackedItems queue =
---     pushList queue unackedItemsList
---     where
---         unackedItemsList = map snd $ Map.toList unackedItems
---         pushList :: Queue Item -> [Item] -> Queue Item
---         pushList queue [] = queue
---         pushList queue (item:items) =
---             pushList queue' items
---             where
---                 queue' = push item queue
+-- Pushes all given unackedItems back into appropriate queues or to appropriate consumers
+handledUnacked :: ServerState -> UnackedItems -> Process ServerState
+handledUnacked state unackedItems = do
+    let itemsList = map snd $ Map.toList unackedItems
+    state' <- pushOrForwardItems state itemsList
+    return state'
+    where
+        pushOrForwardItems :: ServerState -> [Item] -> Process ServerState
+        pushOrForwardItems state [] = return state
+        pushOrForwardItems 
+            (ServerState name clients clientItems queues nextDelivId)
+            ((Item source body):items) = do
+                let state = ServerState name clients clientItems queues nextDelivId
+                case Map.lookup source queues of
+                    Nothing -> do
+                        state' <- pushOrForwardItems state items
+                        return state'
+                    Just sQueue -> do
+                        let item = Item source body
+                        state' <- pushOrForward state item sQueue
+                        state'' <- pushOrForwardItems state' items
+                        return state''
 
--- -- Handler function for when a client acknowledges the receival of an item
--- ackHandler :: ServerState -> Ack -> Process ServerState
--- ackHandler
---     (ServerState name clients clientItems queue nextDelivId)
---     (Ack ackerId delivId) = do
---         say $ "Received ack message from " ++ show ackerId
---         case Map.lookup ackerId clients of
---             -- If message received from unconnected client
---             Nothing -> do
---                 say "Client was unconnected..."
---                 -- Tell unconnected client that they're unrecognized by server
---                 send ackerId UnrecognizedClientNotification
---                 -- Drop message and return state
---                 return $ ServerState name clients clientItems queue nextDelivId
---             -- If message is received from connected client
---             Just clientRef -> do
---                 say "Client was connected, attempting to pull unacked items map..."
---                 -- Get acker's unackedItems map 
---                 case Map.lookup ackerId clientItems of
---                     -- If acker's unackedItems map doesn't exist, close connection
---                     Nothing -> do
---                         say "Client had no map. Closing false connection..."
---                         -- Delete client entry
---                         let clients' = Map.delete ackerId clients
---                         -- Unmonitor client
---                         unmonitor clientRef
---                         -- Return modified state
---                         return $ ServerState name clients' clientItems queue nextDelivId
---                     -- If acker's unackedItems map exists, remove acked item
---                     Just unackedItems -> do
---                         say "Client had a map, finding message to be acked in their items..."
---                         case Map.notMember delivId unackedItems of
---                             -- If the ack is false, close the client's connection
---                             True -> do
---                                 say "Item not found. Closing false connection..."
---                                 -- Send client connection closed message
---                                 send ackerId $ ConnectionClosedNotification FalseAck
---                                 -- Add all unacked items of that client back into the queue
---                                 let queue' = pushUnacked unackedItems queue
---                                     -- Delete clientItems entry
---                                     clientItems' = Map.delete ackerId clientItems
---                                     -- Delete client entry
---                                     clients' = Map.delete ackerId clients
---                                 -- Unmonitor client
---                                 unmonitor clientRef
---                                 -- Return modified state
---                                 return $ ServerState name clients' clientItems' queue' nextDelivId
---                             False -> do
---                                 say "Item found. Removing item from their unacked items..."
---                                 let unackedItems' = Map.delete delivId unackedItems
---                                     clientItems' = Map.insert ackerId unackedItems' clientItems
---                                 -- Return modified state
---                                 return $ ServerState name clients clientItems' queue nextDelivId
+-- Removes client as consumer from server queue
+removeConsumption :: ClientId -> ServerQueue -> ServerQueue
+removeConsumption clientId (ServerQueue queue exFlag consumers)
+    | isEmpty consumers = (ServerQueue queue exFlag consumers)
+    | isElem clientId consumers = removeConsumer clientId (ServerQueue queue exFlag consumers)
+        where
+            removeConsumer :: ClientId -> ServerQueue -> ServerQueue
+            removeConsumer clientId (ServerQueue queue exFlag consumers)
+                | exFlag = ServerQueue queue False emptyQueue
+                | otherwise = ServerQueue queue exFlag consumers'
+                    where consumers' = removeQueueElem clientId consumers
+
+-- Removes client as a consumer from all server queues
+handleConsumptions :: ServerState -> ClientId -> Process ServerState
+handleConsumptions 
+    (ServerState name clients clientItems queues nextDelivId)
+    clientId = do
+        let queues' = Map.map (removeConsumption clientId) queues
+        return $ ServerState name clients clientItems queues' nextDelivId
+
+-- Removes client as a consumer from all queues, handles their unacked items, and unmonitors them
+handleClose :: ServerState -> ClientId -> UnackedItems -> MonitorRef -> Process ServerState
+handleClose state clientId unackedItems clientRef = do
+    state' <- handledUnacked state unackedItems
+    (ServerState name clients clientItems' queues' nextDelivId') <- handleConsumptions state' clientId
+    let clients' = Map.delete clientId clients
+        clientItems'' = Map.delete clientId clientItems'
+    unmonitor clientRef
+    return $ ServerState name clients' clientItems'' queues' nextDelivId'
+
+-- Handler function for when a client acknowledges the receival of an item
+ackHandler :: ServerState -> Ack -> Process ServerState
+ackHandler
+    (ServerState name clients clientItems queues nextDelivId)
+    (Ack ackerId delivId) = do
+        say $ "Received ack message from " ++ show ackerId
+        case Map.lookup ackerId clients of
+            -- If message received from unconnected client
+            Nothing -> do
+                say "Client was unconnected..."
+                -- Tell unconnected client that they're unrecognized by server
+                send ackerId UnrecognizedClientNotification
+                -- Drop message and return state
+                return $ ServerState name clients clientItems queues nextDelivId
+            -- If message is received from connected client
+            Just clientRef -> do
+                say "Client was connected, attempting to pull unacked items map..."
+                let state = ServerState name clients clientItems queues nextDelivId
+                -- Get acker's unackedItems map 
+                case Map.lookup ackerId clientItems of
+                    -- If acker's unackedItems map doesn't exist, close connection
+                    Nothing -> do
+                        say "No unacked items. Removing consumptions and unmonitoring this client..."
+                        (ServerState name' clients' clientItems' queues' nextDelivId') <- handleConsumptions state ackerId
+                        -- Delete client entry
+                        let clients'' = Map.delete ackerId clients'
+                        -- Unmonitor client
+                        unmonitor clientRef
+                        -- Send client connection closed message
+                        send ackerId $ ConnectionClosedNotification FalseAck
+                        -- Return modified state
+                        return $ ServerState name' clients'' clientItems' queues' nextDelivId'
+                    -- If acker's unackedItems map exists, remove acked item
+                    Just unackedItems -> do
+                        say "Client had a map, finding message to be acked in their items..."
+                        case Map.notMember delivId unackedItems of
+                            -- If the ack is false, close the client's connection
+                            True -> do
+                                say "Item not found. Closing false connection..."
+                                -- Send client connection closed message
+                                send ackerId $ ConnectionClosedNotification FalseAck
+                                -- Remove client from server data gracefully
+                                state' <- handleClose state ackerId unackedItems clientRef
+                                return state'
+                            False -> do
+                                say "Item found. Removing item from their unacked items..."
+                                let unackedItems' = Map.delete delivId unackedItems
+                                    clientItems' = Map.insert ackerId unackedItems' clientItems
+                                -- Return modified state
+                                return $ ServerState name clients clientItems' queues nextDelivId
                         
--- -- Handler function for when a client negatively acknowledges the receival of an item
--- nackHandler :: ServerState -> Nack -> Process ServerState
--- nackHandler 
---     (ServerState name clients clientItems queue nextDelivId)
---     (Nack nackerId delivId) = do
---         say $ "Received nack message from " ++ show nackerId
---         case Map.lookup nackerId clients of
---             -- If message receive from unconnected client
---             Nothing -> do
---                 say "Client was unconnected..."
---                 -- Tell unconnected client that they're unrecognized by server
---                 send nackerId UnrecognizedClientNotification
---                 -- Drop message and return state
---                 return $ ServerState name clients clientItems queue nextDelivId
---             -- If message is received from connected client
---             Just clientRef -> do
---                 say "Client was connected, attempting to pull unacked items map..."
---                 -- Get acker's unackedItems map 
---                 case Map.lookup nackerId clientItems of
---                     -- If acker's unackedItems map doesn't exist, close connection
---                     Nothing -> do
---                         say "Client had no map. Closing false connection..."
---                         -- Delete client entry
---                         let clients' = Map.delete nackerId clients
---                         -- Unmonitor client
---                         unmonitor clientRef
---                         -- Return modified state
---                         return $ ServerState name clients' clientItems queue nextDelivId
---                     -- If nacker's unackedItems map exists, remove nacked item and push it to queue
---                     Just unackedItems -> do
---                         say "Client had a map, finding message to be acked in their items..."
---                         case Map.lookup delivId unackedItems of
---                             -- If the nack is false, close the client's connection
---                             Nothing -> do
---                                 say "Item not found. Closing false connection..."
---                                 -- Send client connection closed message
---                                 send nackerId $ ConnectionClosedNotification FalseAck
---                                 -- Add all unacked items of that client back into the queue
---                                 let queue' = pushUnacked unackedItems queue
---                                     -- Delete clientItems entry
---                                     clientItems' = Map.delete nackerId clientItems
---                                     -- Delete client entry
---                                     clients' = Map.delete nackerId clients
---                                 -- Unmonitor client
---                                 unmonitor clientRef
---                                 -- Return modified state
---                                 return $ ServerState name clients' clientItems' queue' nextDelivId
---                             Just item -> do
---                                 say "Item found. Removing item from their unacked items..."
---                                 let unackedItems' = Map.delete delivId unackedItems
---                                     clientItems' = Map.insert nackerId unackedItems' clientItems
---                                     queue' = push item queue
---                                 -- Return modified state
---                                 return $ ServerState name clients clientItems' queue' nextDelivId
+-- Handler function for when a client negatively acknowledges the receival of an item
+nackHandler :: ServerState -> Nack -> Process ServerState
+nackHandler 
+    (ServerState name clients clientItems queues nextDelivId)
+    (Nack nackerId delivId) = do
+        say $ "Received nack message from " ++ show nackerId
+        case Map.lookup nackerId clients of
+            -- If message receive from unconnected client
+            Nothing -> do
+                say "Client was unconnected..."
+                -- Tell unconnected client that they're unrecognized by server
+                send nackerId UnrecognizedClientNotification
+                -- Drop message and return state
+                return $ ServerState name clients clientItems queues nextDelivId
+            -- If message is received from connected client
+            Just clientRef -> do
+                say "Client was connected, attempting to pull unacked items map..."
+                let state = ServerState name clients clientItems queues nextDelivId
+                -- Get acker's unackedItems map 
+                case Map.lookup nackerId clientItems of
+                    -- If acker's unackedItems map doesn't exist, close connection
+                    Nothing -> do
+                        say "No unacked items. Removing consumptions and unmonitoring this client..."
+                        (ServerState name' clients' clientItems' queues' nextDelivId') <- handleConsumptions state nackerId
+                        -- Delete client entry
+                        let clients'' = Map.delete nackerId clients'
+                        -- Unmonitor client
+                        unmonitor clientRef
+                        -- Send client connection closed message
+                        send nackerId $ ConnectionClosedNotification FalseNack
+                        -- Return modified state
+                        return $ ServerState name' clients'' clientItems' queues' nextDelivId'
+                    -- If nacker's unackedItems map exists, remove nacked item and push it to queue
+                    Just unackedItems -> do
+                        say "Client had a map, finding message to be acked in their items..."
+                        case Map.lookup delivId unackedItems of
+                            -- If the nack is false, close the client's connection
+                            Nothing -> do
+                                say "Item not found. Closing false connection..."
+                                -- Send client connection closed message
+                                send nackerId $ ConnectionClosedNotification FalseNack
+                                -- Remove client from server data gracefully
+                                state' <- handleClose state nackerId unackedItems clientRef
+                                -- Return modified state
+                                return state'
+                            Just item -> do
+                                say "Item found. Removing item from their unacked items..."
+                                let unackedItems' = Map.delete delivId unackedItems
+                                    clientItems' = Map.insert nackerId unackedItems' clientItems
+                                -- Return modified state
+                                return $ ServerState name clients clientItems' queues nextDelivId
 
--- -- Handler function for client disconnects
--- disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
--- disconnectHandler
---     (ServerState name clients clientItems queue nextDelivId)
---     (ProcessMonitorNotification disconnectRef disconnectId _) = do
---         say "Received a disconnect notification..."
---         case Map.notMember disconnectId clients of
---             -- If disconnect message is not for a client
---             True -> do
---                 say "Received notification for unconnected client. Unmonitor this false client..."
---                 -- Unmonitor this non-client
---                 unmonitor disconnectRef
---                 -- Return modified state
---                 return $ ServerState name clients clientItems queue nextDelivId
---             -- If disconnect message is for a client
---             False -> do
---                 say "Received notification for connected client. Checking for unacked items..."
---                 case Map.lookup disconnectId clientItems of
---                     -- If disconnecter does not an unackedItems entry
---                     Nothing -> do
---                         say "No unacked items. Unmonitoring this client..."
---                         -- Delete client entry
---                         let clients' = Map.delete disconnectId clients
---                         -- Unmonitor client
---                         unmonitor disconnectRef
---                         -- Return modified state
---                         return $ ServerState name clients' clientItems queue nextDelivId
---                     -- If disconnect does have an unackedItems entry
---                     Just unackedItems -> do
---                         say "Found unacked items. Pushing them back onto the queue and unmonitoring client..."
---                         -- Add all unacked items of that client back into the queue
---                         let queue' = pushUnacked unackedItems queue
---                             -- Delete clientItems entry
---                             clientItems' = Map.delete disconnectId clientItems
---                             -- Delete client entry
---                             clients' = Map.delete disconnectId clients
---                         -- Unmonitor client
---                         unmonitor disconnectRef
---                         -- Return modifified state
---                         return $ ServerState name clients' clientItems' queue' nextDelivId
+-- Handler function for client disconnects
+disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
+disconnectHandler
+    (ServerState name clients clientItems queues nextDelivId)
+    (ProcessMonitorNotification disconnectRef disconnectId _) = do
+        say "Received a disconnect notification..."
+        case Map.notMember disconnectId clients of
+            -- If disconnect message is not for a client
+            True -> do
+                say "Received notification for unconnected client. Unmonitor this false client..."
+                -- Unmonitor this non-client
+                unmonitor disconnectRef
+                -- Return modified state
+                return $ ServerState name clients clientItems queues nextDelivId
+            -- If disconnect message is for a client
+            False -> do
+                say "Received notification for connected client. Checking for unacked items..."
+                let state = ServerState name clients clientItems queues nextDelivId
+                case Map.lookup disconnectId clientItems of
+                    -- If disconnecter does not an unackedItems entry
+                    Nothing -> do
+                        say "No unacked items. Removing consumptions and unmonitoring this client..."
+                        (ServerState name' clients' clientItems' queues' nextDelivId') <- handleConsumptions state disconnectId
+                        -- Delete client entry
+                        let clients'' = Map.delete disconnectId clients'
+                        -- Unmonitor client
+                        unmonitor disconnectRef
+                        -- Return modified state
+                        return $ ServerState name' clients'' clientItems' queues' nextDelivId'
+                    -- If disconnect does have an unackedItems entry
+                    Just unackedItems -> do
+                        say "Found unacked items. Pushing them back onto the queue and unmonitoring client..."
+                        -- Remove client from server data gracefully
+                        state' <- handleClose state disconnectId unackedItems disconnectRef
+                        return state'
+                        
+
+-- Handler function for queue declaration messages
+queueDeclareHandler :: ServerState -> QueueDeclare -> Process ServerState
+queueDeclareHandler
+    (ServerState name clients clientItems queues nextDelivId)
+    (QueueDeclare declarerId queueName) = do
+        say $ "Received queue declare message from " ++ show declarerId
+        case Map.notMember declarerId clients of
+            -- If message received from unconnected client
+            True -> do
+                say "Client was unconnected..."
+                -- Tell unconnected client that they're unrecognized by server
+                send declarerId UnrecognizedClientNotification
+                -- Drop message and return state
+                return $ ServerState name clients clientItems queues nextDelivId
+            -- If message is received from connected client
+            False -> do
+                case Map.lookup queueName queues of
+                    -- If queue exists,
+                    Just sQueue -> do 
+                        -- Queue declaration is idempotent, just return unmodified state
+                        return (ServerState name clients clientItems queues nextDelivId)
+                    -- If queue doesn't exist,
+                    Nothing -> do
+                        -- Construct a new queue and insert it into ServerQueues
+                        let sQueue = ServerQueue emptyQueue False emptyQueue
+                            queues' = Map.insert queueName sQueue queues
+                        -- Return modified state
+                        return $ ServerState name clients clientItems queues' nextDelivId
+                    
+-- Handler function for consume messages
+consumeHandler :: ServerState -> Consume -> Process ServerState
+consumeHandler
+    (ServerState name clients clientItems queues nextDelivId)
+    (Consume consumerId queueName exclusive) = do
+        say $ "Received consume message from " ++ show consumerId
+        let state = ServerState name clients clientItems queues nextDelivId
+        case Map.notMember consumerId clients of
+            -- If message received from unconnected client
+            True -> do
+                say "Client was unconnected..."
+                -- Tell unconnected client that they're unrecognized by server
+                send consumerId UnrecognizedClientNotification
+                -- Drop message and return state
+                return state
+            -- If message is received from connected client
+            False -> do
+                say "Looking up server queue..."
+                case Map.lookup queueName queues of
+                    -- If queue doesn't exist,
+                    Nothing -> do
+                        say "Queue was not found. Responding with error..."
+                        -- Send unrecognized queue notification
+                        send consumerId UnrecognizedQueueNameNotification
+                        -- Drop message and return state
+                        return state
+                    -- If queue does exist,
+                    Just (ServerQueue queue exFlag consumers) -> do
+                        say "Checking if queue is exclusive..."
+                        case exFlag of
+                            True -> do
+                                say "Queue is marked exclusive. Responding with error..."
+                                -- Send error for when a queue is marked exclusive
+                                send consumerId RegisteredExclusiveConsumer
+                                -- Drop message and return state
+                                return state
+                            False -> do
+                                say "Queue is not marked exclusive. Checking valid consumption..."
+                                case (exclusive && (not (isEmpty consumers))) of
+                                    True -> do
+                                        say "Attempting exclusive consumption of queue with consumers. Responding with error..."
+                                        send consumerId RegisteredConsumersOnExclusive
+                                        -- Drop message and return state
+                                        return state
+                                    False -> do
+                                        say "Queue consumption is valid. Adding to server queue consumers..."
+                                        let consumers' = push consumerId consumers
+                                        case exclusive of
+                                            -- Register consumer as exclusive consumer of queue
+                                            True -> do
+                                                let sQueue = ServerQueue queue True consumers'
+                                                    queues' = Map.insert queueName sQueue queues
+                                                return $ ServerState name clients clientItems queues' nextDelivId
+                                            -- Register consumer as non-exclsuive consumer of queue
+                                            False -> do
+                                                let sQueue = ServerQueue queue exFlag consumers'
+                                                    queues' = Map.insert queueName sQueue queues
+                                                return $ ServerState name clients clientItems queues' nextDelivId
 
 -- publishHandler :: ServerState -> Publish -> Process ServerState
 -- publishHandler state _ = return state
@@ -305,17 +484,17 @@ getHandler
 -- getHandler :: ServerState -> Get -> Process ServerState
 -- getHandler state _ = return state
 
-ackHandler :: ServerState -> Ack -> Process ServerState
-ackHandler state _ = return state
+-- ackHandler :: ServerState -> Ack -> Process ServerState
+-- ackHandler state _ = return state
 
-nackHandler :: ServerState -> Nack -> Process ServerState
-nackHandler state _ = return state
+-- nackHandler :: ServerState -> Nack -> Process ServerState
+-- nackHandler state _ = return state
 
-disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
-disconnectHandler state _ = return state
+-- disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
+-- disconnectHandler state _ = return state
 
-queueDeclareHandler :: ServerState -> QueueDeclare -> Process ServerState
-queueDeclareHandler state _ = return state
+-- queueDeclareHandler :: ServerState -> QueueDeclare -> Process ServerState
+-- queueDeclareHandler state _ = return state
 
-consumeHandler :: ServerState -> Consume -> Process ServerState
-consumeHandler state _ = return state
+-- consumeHandler :: ServerState -> Consume -> Process ServerState
+-- consumeHandler state _ = return state

--- a/src/ServerHandlers.hs
+++ b/src/ServerHandlers.hs
@@ -10,7 +10,7 @@ import Queue
 -- Handler function for connecting a new client to the server
 clientConnHandler :: ServerState -> ClientConnection -> Process ServerState
 clientConnHandler 
-    (ServerState name clients clientItems queue nextDelivId)
+    (ServerState name clients clientItems queues nextDelivId)
     (ClientConnection newClientId) = do
         say "Received client connection message..."
         case Map.member newClientId clients of
@@ -20,25 +20,26 @@ clientConnHandler
                 -- Reconfirm with client that they're connected
                 send newClientId ConfirmConnection
                 -- Return state
-                return $ ServerState name clients clientItems queue nextDelivId
+                return $ ServerState name clients clientItems queues nextDelivId
             -- If client is a new connection
             False -> do
                 say "Client was not connected, adding client to map..."
                 -- Start monitoring new client
                 clientMonitorRef <- monitor newClientId
-                -- Add client to clients map and initialize there unacked items map
+                -- Add client to clients map and initialize their unacked items map
                 let clients' = Map.insert newClientId clientMonitorRef clients
                     clientItems' = Map.insert newClientId Map.empty clientItems
                 -- Confirm with client that they're connected
                 send newClientId ConfirmConnection
                 -- Return modified state
-                return $ ServerState name clients' clientItems' queue nextDelivId
+                return $ ServerState name clients' clientItems' queues nextDelivId
 
+-- publish still needs to forward message to next consumer if there is one
 -- Handler function for when a client publishes an item to the queue
 publishHandler :: ServerState -> Publish -> Process ServerState
 publishHandler 
-    (ServerState name clients clientItems queue nextDelivId)
-    (Publish publisherId itemId itemBody) = do
+    (ServerState name clients clientItems queues nextDelivId)
+    (Publish publisherId itemId itemBody queueName) = do
         say $ "Received publish message from " ++ show publisherId
         case Map.notMember publisherId clients of
             -- If message received from unconnected client
@@ -47,22 +48,32 @@ publishHandler
                 -- Tell unconnected client that they're unrecognized by server
                 send publisherId UnrecognizedClientNotification
                 -- Drop message and return state
-                return $ ServerState name clients clientItems queue nextDelivId
+                return $ ServerState name clients clientItems queues nextDelivId
             -- If message is received from connected client
             False -> do
-                say "Client was connected, added item to queue..."
-                -- Add item to queue
-                let queue' = push itemBody queue
-                -- Confirm receipt to publisher
-                send publisherId $ Confirm itemId
-                -- Return modified state
-                return $ ServerState name clients clientItems queue' nextDelivId
+                -- Lookup server queue by name
+                case Map.lookup queueName queues of
+                    -- If queue doesn't exist,
+                    Nothing -> do
+                        -- Send an unrecognized queue name notification
+                        send publisherId UnrecognizedQueueNameNotification
+                        -- Return state
+                        return $ ServerState name clients clientItems queues nextDelivId
+                    -- If queue does exist,
+                    Just (ServerQueue queue exFlag consumers) -> do
+                        -- Push the new item into the queue and update the ServerQueues map
+                        let queue' = push (Item queueName itemBody) queue
+                            queues' = Map.insert queueName (ServerQueue queue' exFlag consumers) queues
+                        -- Confirm receipt to publisher
+                        send publisherId $ Confirm itemId
+                        -- Return modified state
+                        return $ ServerState name clients clientItems queues' nextDelivId
 
 -- Handler function for when a client requests an item from the queue
 getHandler :: ServerState -> Get -> Process ServerState
 getHandler
-    (ServerState name clients clientItems queue nextDelivId)
-    (Get getterId) = do
+    (ServerState name clients clientItems queues nextDelivId)
+    (Get getterId queueName) = do
         say $ "Received get message from " ++ show getterId
         case Map.notMember getterId clients of
             -- If message received from unconnected client
@@ -71,202 +82,240 @@ getHandler
                 -- Tell unconnected client that they're unrecognized by server
                 send getterId UnrecognizedClientNotification
                 -- Drop message and return state
-                return $ ServerState name clients clientItems queue nextDelivId
+                return $ ServerState name clients clientItems queues nextDelivId
             -- If message is received from connected client
             False -> do
-                say "Client was connected, attempting to pop item from queue..."
-                -- Pop an item from the queue
-                let (queue', maybeItem) = pop queue
-                case maybeItem of
-                    -- If queue is emtpy
+                case Map.lookup queueName queues of
+                    -- If queue doesn't exist,
                     Nothing -> do
-                        say "Queue was empty, responding appropriately..."
-                        -- Send empty queue notif to client
-                        send getterId EmptyQueueNotification
-                        -- Return modified state
-                        return $ ServerState name clients clientItems queue' nextDelivId
-                    -- If queue is not empty
-                    Just item -> do
-                        say "Queue was not empty, responding with item..."
-                        -- Increment deliveryId counter
-                        let nextDelivId' = nextDelivId + 1
-                        -- Get getter's unackedItems map                      
-                        case Map.lookup getterId clientItems of
-                            -- If getter's unackedItems map doesn't exist, create it and insert it
-                            Nothing -> do
-                                let unackedItems' = Map.fromList [(nextDelivId, item)]
-                                    clientItems' = Map.insert getterId unackedItems' clientItems
-                                -- Send item to getter
-                                send getterId $ Delivery nextDelivId item
-                                -- Return modified state
-                                return $ ServerState name clients clientItems' queue' nextDelivId'
-                            -- If getter's unackedItems map exists, insert unacked item
-                            Just unackedItems -> do
-                                let unackedItems' = Map.insert nextDelivId item unackedItems
-                                    clientItems' = Map.insert getterId unackedItems' clientItems
-                                -- Send item to getter
-                                send getterId $ Delivery nextDelivId item
-                                -- Return modified state
-                                return $ ServerState name clients clientItems' queue' nextDelivId'
-
-pushUnacked :: UnackedItems -> Queue Item -> Queue Item
-pushUnacked unackedItems queue =
-    pushList queue unackedItemsList
-    where
-        unackedItemsList = map snd $ Map.toList unackedItems
-        pushList :: Queue Item -> [Item] -> Queue Item
-        pushList queue [] = queue
-        pushList queue (item:items) =
-            pushList queue' items
-            where
-                queue' = push item queue
-
--- Handler function for when a client acknowledges the receival of an item
-ackHandler :: ServerState -> Ack -> Process ServerState
-ackHandler
-    (ServerState name clients clientItems queue nextDelivId)
-    (Ack ackerId delivId) = do
-        say $ "Received ack message from " ++ show ackerId
-        case Map.lookup ackerId clients of
-            -- If message received from unconnected client
-            Nothing -> do
-                say "Client was unconnected..."
-                -- Tell unconnected client that they're unrecognized by server
-                send ackerId UnrecognizedClientNotification
-                -- Drop message and return state
-                return $ ServerState name clients clientItems queue nextDelivId
-            -- If message is received from connected client
-            Just clientRef -> do
-                say "Client was connected, attempting to pull unacked items map..."
-                -- Get acker's unackedItems map 
-                case Map.lookup ackerId clientItems of
-                    -- If acker's unackedItems map doesn't exist, close connection
-                    Nothing -> do
-                        say "Client had no map. Closing false connection..."
-                        -- Delete client entry
-                        let clients' = Map.delete ackerId clients
-                        -- Unmonitor client
-                        unmonitor clientRef
-                        -- Return modified state
-                        return $ ServerState name clients' clientItems queue nextDelivId
-                    -- If acker's unackedItems map exists, remove acked item
-                    Just unackedItems -> do
-                        say "Client had a map, finding message to be acked in their items..."
-                        case Map.notMember delivId unackedItems of
-                            -- If the ack is false, close the client's connection
+                        -- Send an unrecognized queue name notification
+                        send getterId UnrecognizedQueueNameNotification
+                        -- Return state
+                        return $ ServerState name clients clientItems queues nextDelivId
+                    -- If queue does exist,
+                    Just (ServerQueue queue exFlag consumers) -> do
+                        case exFlag of
+                            -- If queue is being exclusively consumed,
                             True -> do
-                                say "Item not found. Closing false connection..."
-                                -- Send client connection closed message
-                                send ackerId $ ConnectionClosedNotification FalseAck
-                                -- Add all unacked items of that client back into the queue
-                                let queue' = pushUnacked unackedItems queue
-                                    -- Delete clientItems entry
-                                    clientItems' = Map.delete ackerId clientItems
-                                    -- Delete client entry
-                                    clients' = Map.delete ackerId clients
-                                -- Unmonitor client
-                                unmonitor clientRef
-                                -- Return modified state
-                                return $ ServerState name clients' clientItems' queue' nextDelivId
+                                -- Send a get error notification
+                                send getterId ExclusiveConsumerNotification
+                                -- Return state
+                                return $ ServerState name clients clientItems queues nextDelivId
+                            -- If queue is not being exclusively consumed,
                             False -> do
-                                say "Item found. Removing item from their unacked items..."
-                                let unackedItems' = Map.delete delivId unackedItems
-                                    clientItems' = Map.insert ackerId unackedItems' clientItems
-                                -- Return modified state
-                                return $ ServerState name clients clientItems' queue nextDelivId
-                        
--- Handler function for when a client negatively acknowledges the receival of an item
-nackHandler :: ServerState -> Nack -> Process ServerState
-nackHandler 
-    (ServerState name clients clientItems queue nextDelivId)
-    (Nack nackerId delivId) = do
-        say $ "Received nack message from " ++ show nackerId
-        case Map.lookup nackerId clients of
-            -- If message receive from unconnected client
-            Nothing -> do
-                say "Client was unconnected..."
-                -- Tell unconnected client that they're unrecognized by server
-                send nackerId UnrecognizedClientNotification
-                -- Drop message and return state
-                return $ ServerState name clients clientItems queue nextDelivId
-            -- If message is received from connected client
-            Just clientRef -> do
-                say "Client was connected, attempting to pull unacked items map..."
-                -- Get acker's unackedItems map 
-                case Map.lookup nackerId clientItems of
-                    -- If acker's unackedItems map doesn't exist, close connection
-                    Nothing -> do
-                        say "Client had no map. Closing false connection..."
-                        -- Delete client entry
-                        let clients' = Map.delete nackerId clients
-                        -- Unmonitor client
-                        unmonitor clientRef
-                        -- Return modified state
-                        return $ ServerState name clients' clientItems queue nextDelivId
-                    -- If nacker's unackedItems map exists, remove nacked item and push it to queue
-                    Just unackedItems -> do
-                        say "Client had a map, finding message to be acked in their items..."
-                        case Map.lookup delivId unackedItems of
-                            -- If the nack is false, close the client's connection
-                            Nothing -> do
-                                say "Item not found. Closing false connection..."
-                                -- Send client connection closed message
-                                send nackerId $ ConnectionClosedNotification FalseAck
-                                -- Add all unacked items of that client back into the queue
-                                let queue' = pushUnacked unackedItems queue
-                                    -- Delete clientItems entry
-                                    clientItems' = Map.delete nackerId clientItems
-                                    -- Delete client entry
-                                    clients' = Map.delete nackerId clients
-                                -- Unmonitor client
-                                unmonitor clientRef
-                                -- Return modified state
-                                return $ ServerState name clients' clientItems' queue' nextDelivId
-                            Just item -> do
-                                say "Item found. Removing item from their unacked items..."
-                                let unackedItems' = Map.delete delivId unackedItems
-                                    clientItems' = Map.insert nackerId unackedItems' clientItems
-                                    queue' = push item queue
-                                -- Return modified state
-                                return $ ServerState name clients clientItems' queue' nextDelivId
+                                -- Pop an item from the queue
+                                let (queue', maybeItem) = pop queue
+                                case maybeItem of
+                                    -- If queue is empty,
+                                    Nothing -> do
+                                        -- Send empty queue notif to client
+                                        send getterId EmptyQueueNotification
+                                        -- Return state
+                                        return $ ServerState name clients clientItems queues nextDelivId
+                                    -- If queue is not empty,
+                                    Just (Item source body) -> do
+                                        let nextDelivId' = nextDelivId + 1
+                                            item = Item source body
+                                        -- Get getter's unackedItems map
+                                        case Map.lookup getterId clientItems of
+                                            -- If getter's unackedItems map doens't exist, create it and insert it
+                                            Nothing -> do
+                                                let unackedItems' = Map.fromList [(nextDelivId, item)]
+                                                    clientItems' = Map.insert getterId unackedItems' clientItems
+                                                    queues' = Map.insert queueName (ServerQueue queue' exFlag consumers) queues
+                                                -- Send item to getter
+                                                send getterId $ Delivery nextDelivId body
+                                                -- Return modified state
+                                                return $ ServerState name clients clientItems' queues' nextDelivId'
+                                            -- If getter's unackedItems map does exist, insert the item
+                                            Just unackedItems -> do
+                                                let unackedItems' = Map.insert nextDelivId item unackedItems
+                                                    clientItems' = Map.insert getterId unackedItems' clientItems
+                                                    queues' = Map.insert queueName (ServerQueue queue' exFlag consumers) queues
+                                                -- Send item to getter
+                                                send getterId $ Delivery nextDelivId body
+                                                -- Return modified state
+                                                return $ ServerState name clients clientItems' queues' nextDelivId'
 
--- Handler function for client disconnects
+-- pushUnacked :: UnackedItems -> Queue Item -> Queue Item
+-- pushUnacked unackedItems queue =
+--     pushList queue unackedItemsList
+--     where
+--         unackedItemsList = map snd $ Map.toList unackedItems
+--         pushList :: Queue Item -> [Item] -> Queue Item
+--         pushList queue [] = queue
+--         pushList queue (item:items) =
+--             pushList queue' items
+--             where
+--                 queue' = push item queue
+
+-- -- Handler function for when a client acknowledges the receival of an item
+-- ackHandler :: ServerState -> Ack -> Process ServerState
+-- ackHandler
+--     (ServerState name clients clientItems queue nextDelivId)
+--     (Ack ackerId delivId) = do
+--         say $ "Received ack message from " ++ show ackerId
+--         case Map.lookup ackerId clients of
+--             -- If message received from unconnected client
+--             Nothing -> do
+--                 say "Client was unconnected..."
+--                 -- Tell unconnected client that they're unrecognized by server
+--                 send ackerId UnrecognizedClientNotification
+--                 -- Drop message and return state
+--                 return $ ServerState name clients clientItems queue nextDelivId
+--             -- If message is received from connected client
+--             Just clientRef -> do
+--                 say "Client was connected, attempting to pull unacked items map..."
+--                 -- Get acker's unackedItems map 
+--                 case Map.lookup ackerId clientItems of
+--                     -- If acker's unackedItems map doesn't exist, close connection
+--                     Nothing -> do
+--                         say "Client had no map. Closing false connection..."
+--                         -- Delete client entry
+--                         let clients' = Map.delete ackerId clients
+--                         -- Unmonitor client
+--                         unmonitor clientRef
+--                         -- Return modified state
+--                         return $ ServerState name clients' clientItems queue nextDelivId
+--                     -- If acker's unackedItems map exists, remove acked item
+--                     Just unackedItems -> do
+--                         say "Client had a map, finding message to be acked in their items..."
+--                         case Map.notMember delivId unackedItems of
+--                             -- If the ack is false, close the client's connection
+--                             True -> do
+--                                 say "Item not found. Closing false connection..."
+--                                 -- Send client connection closed message
+--                                 send ackerId $ ConnectionClosedNotification FalseAck
+--                                 -- Add all unacked items of that client back into the queue
+--                                 let queue' = pushUnacked unackedItems queue
+--                                     -- Delete clientItems entry
+--                                     clientItems' = Map.delete ackerId clientItems
+--                                     -- Delete client entry
+--                                     clients' = Map.delete ackerId clients
+--                                 -- Unmonitor client
+--                                 unmonitor clientRef
+--                                 -- Return modified state
+--                                 return $ ServerState name clients' clientItems' queue' nextDelivId
+--                             False -> do
+--                                 say "Item found. Removing item from their unacked items..."
+--                                 let unackedItems' = Map.delete delivId unackedItems
+--                                     clientItems' = Map.insert ackerId unackedItems' clientItems
+--                                 -- Return modified state
+--                                 return $ ServerState name clients clientItems' queue nextDelivId
+                        
+-- -- Handler function for when a client negatively acknowledges the receival of an item
+-- nackHandler :: ServerState -> Nack -> Process ServerState
+-- nackHandler 
+--     (ServerState name clients clientItems queue nextDelivId)
+--     (Nack nackerId delivId) = do
+--         say $ "Received nack message from " ++ show nackerId
+--         case Map.lookup nackerId clients of
+--             -- If message receive from unconnected client
+--             Nothing -> do
+--                 say "Client was unconnected..."
+--                 -- Tell unconnected client that they're unrecognized by server
+--                 send nackerId UnrecognizedClientNotification
+--                 -- Drop message and return state
+--                 return $ ServerState name clients clientItems queue nextDelivId
+--             -- If message is received from connected client
+--             Just clientRef -> do
+--                 say "Client was connected, attempting to pull unacked items map..."
+--                 -- Get acker's unackedItems map 
+--                 case Map.lookup nackerId clientItems of
+--                     -- If acker's unackedItems map doesn't exist, close connection
+--                     Nothing -> do
+--                         say "Client had no map. Closing false connection..."
+--                         -- Delete client entry
+--                         let clients' = Map.delete nackerId clients
+--                         -- Unmonitor client
+--                         unmonitor clientRef
+--                         -- Return modified state
+--                         return $ ServerState name clients' clientItems queue nextDelivId
+--                     -- If nacker's unackedItems map exists, remove nacked item and push it to queue
+--                     Just unackedItems -> do
+--                         say "Client had a map, finding message to be acked in their items..."
+--                         case Map.lookup delivId unackedItems of
+--                             -- If the nack is false, close the client's connection
+--                             Nothing -> do
+--                                 say "Item not found. Closing false connection..."
+--                                 -- Send client connection closed message
+--                                 send nackerId $ ConnectionClosedNotification FalseAck
+--                                 -- Add all unacked items of that client back into the queue
+--                                 let queue' = pushUnacked unackedItems queue
+--                                     -- Delete clientItems entry
+--                                     clientItems' = Map.delete nackerId clientItems
+--                                     -- Delete client entry
+--                                     clients' = Map.delete nackerId clients
+--                                 -- Unmonitor client
+--                                 unmonitor clientRef
+--                                 -- Return modified state
+--                                 return $ ServerState name clients' clientItems' queue' nextDelivId
+--                             Just item -> do
+--                                 say "Item found. Removing item from their unacked items..."
+--                                 let unackedItems' = Map.delete delivId unackedItems
+--                                     clientItems' = Map.insert nackerId unackedItems' clientItems
+--                                     queue' = push item queue
+--                                 -- Return modified state
+--                                 return $ ServerState name clients clientItems' queue' nextDelivId
+
+-- -- Handler function for client disconnects
+-- disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
+-- disconnectHandler
+--     (ServerState name clients clientItems queue nextDelivId)
+--     (ProcessMonitorNotification disconnectRef disconnectId _) = do
+--         say "Received a disconnect notification..."
+--         case Map.notMember disconnectId clients of
+--             -- If disconnect message is not for a client
+--             True -> do
+--                 say "Received notification for unconnected client. Unmonitor this false client..."
+--                 -- Unmonitor this non-client
+--                 unmonitor disconnectRef
+--                 -- Return modified state
+--                 return $ ServerState name clients clientItems queue nextDelivId
+--             -- If disconnect message is for a client
+--             False -> do
+--                 say "Received notification for connected client. Checking for unacked items..."
+--                 case Map.lookup disconnectId clientItems of
+--                     -- If disconnecter does not an unackedItems entry
+--                     Nothing -> do
+--                         say "No unacked items. Unmonitoring this client..."
+--                         -- Delete client entry
+--                         let clients' = Map.delete disconnectId clients
+--                         -- Unmonitor client
+--                         unmonitor disconnectRef
+--                         -- Return modified state
+--                         return $ ServerState name clients' clientItems queue nextDelivId
+--                     -- If disconnect does have an unackedItems entry
+--                     Just unackedItems -> do
+--                         say "Found unacked items. Pushing them back onto the queue and unmonitoring client..."
+--                         -- Add all unacked items of that client back into the queue
+--                         let queue' = pushUnacked unackedItems queue
+--                             -- Delete clientItems entry
+--                             clientItems' = Map.delete disconnectId clientItems
+--                             -- Delete client entry
+--                             clients' = Map.delete disconnectId clients
+--                         -- Unmonitor client
+--                         unmonitor disconnectRef
+--                         -- Return modifified state
+--                         return $ ServerState name clients' clientItems' queue' nextDelivId
+
+-- publishHandler :: ServerState -> Publish -> Process ServerState
+-- publishHandler state _ = return state
+
+-- getHandler :: ServerState -> Get -> Process ServerState
+-- getHandler state _ = return state
+
+ackHandler :: ServerState -> Ack -> Process ServerState
+ackHandler state _ = return state
+
+nackHandler :: ServerState -> Nack -> Process ServerState
+nackHandler state _ = return state
+
 disconnectHandler :: ServerState -> ProcessMonitorNotification -> Process ServerState
-disconnectHandler
-    (ServerState name clients clientItems queue nextDelivId)
-    (ProcessMonitorNotification disconnectRef disconnectId _) = do
-        say "Received a disconnect notification..."
-        case Map.notMember disconnectId clients of
-            -- If disconnect message is not for a client
-            True -> do
-                say "Received notification for unconnected client. Unmonitor this false client..."
-                -- Unmonitor this non-client
-                unmonitor disconnectRef
-                -- Return modified state
-                return $ ServerState name clients clientItems queue nextDelivId
-            -- If disconnect message is for a client
-            False -> do
-                say "Received notification for connected client. Checking for unacked items..."
-                case Map.lookup disconnectId clientItems of
-                    -- If disconnecter does not an unackedItems entry
-                    Nothing -> do
-                        say "No unacked items. Unmonitoring this client..."
-                        -- Delete client entry
-                        let clients' = Map.delete disconnectId clients
-                        -- Unmonitor client
-                        unmonitor disconnectRef
-                        -- Return modified state
-                        return $ ServerState name clients' clientItems queue nextDelivId
-                    -- If disconnect does have an unackedItems entry
-                    Just unackedItems -> do
-                        say "Found unacked items. Pushing them back onto the queue and unmonitoring client..."
-                        -- Add all unacked items of that client back into the queue
-                        let queue' = pushUnacked unackedItems queue
-                            -- Delete clientItems entry
-                            clientItems' = Map.delete disconnectId clientItems
-                            -- Delete client entry
-                            clients' = Map.delete disconnectId clients
-                        -- Unmonitor client
-                        unmonitor disconnectRef
-                        -- Return modifified state
-                        return $ ServerState name clients' clientItems' queue' nextDelivId
+disconnectHandler state _ = return state
+
+queueDeclareHandler :: ServerState -> QueueDeclare -> Process ServerState
+queueDeclareHandler state _ = return state
+
+consumeHandler :: ServerState -> Consume -> Process ServerState
+consumeHandler state _ = return state

--- a/src/ServerTypes.hs
+++ b/src/ServerTypes.hs
@@ -1,10 +1,11 @@
 module ServerTypes where
 
 import Control.Distributed.Process (ProcessId, MonitorRef)
+import Control.Lens.Internal.ByteString (unpackStrict8)
 import Data.ByteString (ByteString)
 import Data.Map (Map)
 
-import Messages (DeliveryId)
+import Messages (DeliveryId, QueueName)
 import Queue (Queue)
 
 type ServerName = String
@@ -12,15 +13,35 @@ type ServerName = String
 type ClientId = ProcessId
 type Clients = Map ClientId MonitorRef
 
-type Item = ByteString
+-- type Item = ByteString
+
+data Item = Item {
+    source :: QueueName,
+    body :: ByteString
+} deriving (Eq)
+
+instance Show Item where
+    show (Item src body) =
+         "Item: { Src: " ++ src ++
+         "; Body: " ++ unpackStrict8 body ++
+         " }"
 
 type UnackedItems = Map DeliveryId Item
 type ClientItems = Map ClientId UnackedItems
+
+data ServerQueue = ServerQueue {
+    queue :: Queue Item,
+    exclusiveConsumer :: Bool,
+    consumers :: Queue ClientId
+    -- can use find to check for consumers (ClientId -> Bool) -> Queue ClientId -> Maybe ClientId
+}
+
+type ServerQueues = Map QueueName ServerQueue
 
 data ServerState = ServerState {
     serverName :: ServerName,
     clients :: Clients,
     clientItems :: ClientItems,
-    queue :: Queue Item,
+    queues :: ServerQueues,
     nextDeliveryId :: DeliveryId
 }


### PR DESCRIPTION
Namely, this adds:

- Separate queues declared by name
- Getting and publisher to those separate queues
- Consuming on a loop from a specified queue (either in an exclusive or non-exclusive fashion)